### PR TITLE
Fix config flow version check

### DIFF
--- a/custom_components/maxcul/config_flow.py
+++ b/custom_components/maxcul/config_flow.py
@@ -186,7 +186,7 @@ def get_cul_version(com_port: Serial or TelnetSerial) -> bool:
 
     # get CUL FW version
     for _ in range(10):
-        com_port.write(b'V')
+        com_port.write(b'V\n')
         time.sleep(1)
         cul_version = com_port.readline() or None
         if cul_version is not None:


### PR DESCRIPTION
Thanks for this missing component in my homeassistent setup!

As I was setting up this custom component, I encountered the same problem as in issue #1. With USB homeassistant would crash and with telnet the same connection dialog would end with a 'cannot connect to device' error.

Some trial and error showed, that the version check does not contain a newline, so the command is never recognized by the CUL and an empty response is read.

This fixes the problem for me, and both USB and Telnet connection setups succeed.