### PR TITLE
2025.1 readiness and other tiny tweaks

### DIFF
--- a/custom_components/maxcul/__init__.py
+++ b/custom_components/maxcul/__init__.py
@@ -86,7 +86,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         service_device_path = service.data[SERVICE_CONF_DEVICE_PATH]
         duration = service.data[SERVICE_CONF_DURATION]
 
-        if service_device_path.replace('telnet://','') != device_path.replace("telnet://",""):
+        if service_device_path.replace('telnet://','') != device_path.replace('telnet://',''):
             return
 
         connection.enable_pairing(duration)

--- a/custom_components/maxcul/config_flow.py
+++ b/custom_components/maxcul/config_flow.py
@@ -2,7 +2,7 @@
 Config flow for MaxCUL custom component
 '''
 
-import time
+import asyncio
 
 from homeassistant.const import (
     CONF_HOST,
@@ -174,20 +174,20 @@ async def test_connection(device_path: str) -> bool:
     except:
         return False
 
-    return get_cul_version(com_port)
+    return await get_cul_version(com_port)
 
-def get_cul_version(com_port: Serial or TelnetSerial) -> bool:
+async def get_cul_version(com_port: Serial or TelnetSerial) -> bool:
     ''' Determine CUL version of serial/telnet device '''
 
     cul_version = None
 
     # was required for my nanoCUL
-    time.sleep(2)
+    await asyncio.sleep(2)
 
     # get CUL FW version
     for _ in range(10):
         com_port.write(b'V\n')
-        time.sleep(1)
+        await asyncio.sleep(1)
         cul_version = com_port.readline() or None
         if cul_version is not None:
             break

--- a/custom_components/maxcul/services.yaml
+++ b/custom_components/maxcul/services.yaml
@@ -3,7 +3,9 @@ enable_pairing:
   fields:
     device_path:
       name: Device Path
-      description: The path of the CUL device for which pairing is enabled
+      description: The path of the CUL device for which pairing shall be enabled
+      default: &default "COM1 or /dev/ttyUSB0 or 192.168.0.1:2323"
+      example: *default 
       selector:
         text:
     duration:


### PR DESCRIPTION
Made integration ready for 2025.1:
- Added async/await where necessary. Fixes #8
- Migrated from deprecated constants, methods and functions to the recent implementations.

Tweaks
- Fixed bug with lovelace UI, where switching from 'off' back to 'manual' is interpreted in UI still as 'off' (when going back from 'off' to 'manual', temperature will now reset to default instead). 
- Added a few conveniences for the pairing service: prefixing telnet:// is not required anymore but optional, when using telnet. 'Fixes' #5
- Also added some default values in the services yaml to guide the user towards the correct `device_path` for enabling pairing. 'Fixes' #5