### PR TITLE
Add support for WallMountedThermostat and Thermostat Plus

### DIFF
--- a/custom_components/maxcul/climate.py
+++ b/custom_components/maxcul/climate.py
@@ -21,8 +21,13 @@ from maxcul._const import (
     ATTR_DEVICE_ID,
     ATTR_DEVICE_TYPE,
     ATTR_DEVICE_SERIAL,
-    HEATING_THERMOSTAT
+    HEATING_THERMOSTAT,
+    HEATING_THERMOSTAT_PLUS,
+    WALL_MOUNTED_THERMOSTAT
 )
+
+# These types of thermostats shall all be handled the same way
+supported_thermostats = [HEATING_THERMOSTAT, HEATING_THERMOSTAT_PLUS, WALL_MOUNTED_THERMOSTAT]
 
 from custom_components.maxcul import (
     ATTR_CONNECTION_DEVICE_PATH,
@@ -34,7 +39,6 @@ from custom_components.maxcul import (
 )
 
 from custom_components.maxcul.max_thermostat import MaxThermostat
-
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_devices):
     ''' Set up the climate platform for the MaxCUL integration from a config entry. '''
@@ -51,7 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
             device[CONF_NAME]
         )
         for device_id, device in config_entry.data.get(CONF_DEVICES).items()
-        if device[CONF_TYPE] == HEATING_THERMOSTAT
+        if device[CONF_TYPE] in supported_thermostats
     ]
     async_add_devices(devices)
 
@@ -62,7 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
             return
 
         device_type = payload.get(ATTR_DEVICE_TYPE)
-        if device_type is not HEATING_THERMOSTAT:
+        if device_type not in supported_thermostats:
             return
 
         device_id = str(payload.get(ATTR_DEVICE_ID))


### PR DESCRIPTION
This change makes it possible to pair and control WallMountedThermostat (and probably also for Heating Thermostat Plus, but not tested).
So this is a fix candidate for #4 

There is still a problem when parsing new State change messages from the WallMountedThermostat in pymaxcul:
```
2025-05-28 16:50:37.952 DEBUG (Thread-5) [maxcul._io] Received new moritz message: Z0F7904701561B60000000059012A00D80D
2025-05-28 16:50:38.170 DEBUG (Thread-4) [maxcul._communication] Received message <WallThermostatStateMessage length:f counter:79 flag:4 group_id:0 sender_id:1561b6 receiver_id:0 raw_payload:59012A00D8 mode:manual dstsetting:0 langateway:1 is_locked:1 rferror:0 battery_low:0 desired_temperature:21.0 display_actual_temperature:1 temperature:21.6 until_str:> (13)
2025-05-28 16:50:38.172 ERROR (Thread-4) [maxcul._communication] Exception <isinstance expected 2 arguments, got 4> was raised while parsing message 'Z0F7904701561B60000000059012A00D80D'. Please consider reporting this as a bug.
```

I am guessing this is related to _communication.py:305:
```
        elif isinstance(msg, WallThermostatStateMessage, SetTemperatureMessage, WallThermostatControlMessage):
            self._send_ack(msg)
```

I am guessing, the three types should be changed to a touple like so:
```
        elif isinstance(msg, (WallThermostatStateMessage, SetTemperatureMessage, WallThermostatControlMessage)):
            self._send_ack(msg)
```

I am a little bit lost how to change pymaxcul library content in my homeassistant python environment, so I was not able to test this (yet)